### PR TITLE
include step contracts:external in start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Running the app
 
    ```bash
    yarn deploy
+   yarn contracts:external
    yarn start
    ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Running the app
 3. run the app, `you'll need to open a new command prompt`
 
    ```bash
-   yarn deploy
    yarn contracts:external
+   yarn deploy
    yarn start
    ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Running the app
 
    ```bash
    yarn deploy
-   yarn contracts:external
    yarn start
    ```
 

--- a/packages/vite-app-ts/package.json
+++ b/packages/vite-app-ts/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "license": "MIT",
   "scripts": {
-    "start": "yarn contracts:external && cross-env ENVIRONMENT=DEVELOPMENT vite --force",
+    "start": "cross-env ENVIRONMENT=DEVELOPMENT vite --force",
     "contracts:external": "yarn shx rm -rf './src/generated/external-contracts' && yarn shx cp -r './scripts/eth-sdk-config.ts.bak' './src/generated/eth-sdk.config.ts' && yarn eth-sdk -p ./src/generated",
     "build": "tsc && yarn build:anttheme && cross-env ENVIRONMENT=PRODUCTION vite build",
     "build:anttheme": "yarn lessc -x -js ./src/styles/themes/light-theme.less ./public/light-theme.css && yarn lessc -x -js ./src/styles/themes/dark-theme.less ./public/dark-theme.css",

--- a/packages/vite-app-ts/package.json
+++ b/packages/vite-app-ts/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "license": "MIT",
   "scripts": {
-    "start": "cross-env ENVIRONMENT=DEVELOPMENT vite --force",
+    "start": "yarn contracts:external && cross-env ENVIRONMENT=DEVELOPMENT vite --force",
     "contracts:external": "yarn shx rm -rf './src/generated/external-contracts' && yarn shx cp -r './scripts/eth-sdk-config.ts.bak' './src/generated/eth-sdk.config.ts' && yarn eth-sdk -p ./src/generated",
     "build": "tsc && yarn build:anttheme && cross-env ENVIRONMENT=PRODUCTION vite build",
     "build:anttheme": "yarn lessc -x -js ./src/styles/themes/light-theme.less ./public/light-theme.css && yarn lessc -x -js ./src/styles/themes/dark-theme.less ./public/dark-theme.css",


### PR DESCRIPTION
I guess it makes sense to include contracts:external in the start script in order to hide it from the user. 