### PR TITLE
Remove localhost calls in non-localhost deployments 

### DIFF
--- a/packages/vite-app-ts/src/config/appConfig.ts
+++ b/packages/vite-app-ts/src/config/appConfig.ts
@@ -14,7 +14,7 @@ export const DEBUG = false;
  * This constant is your target network that the app is pointed at
  * 🤚🏽  Set your target frontend network <--- select your target frontend network(localhost, rinkeby, xdai, mainnet)
  */
-export const TARGET_NETWORK_INFO: TNetworkInfo = NETWORKS.rinkeby;
+export const TARGET_NETWORK_INFO: TNetworkInfo = NETWORKS.localhost;
 
 if (DEBUG) console.log(`📡 Connecting to ${TARGET_NETWORK_INFO.name}`);
 

--- a/packages/vite-app-ts/src/config/appConfig.ts
+++ b/packages/vite-app-ts/src/config/appConfig.ts
@@ -14,7 +14,7 @@ export const DEBUG = false;
  * This constant is your target network that the app is pointed at
  * 🤚🏽  Set your target frontend network <--- select your target frontend network(localhost, rinkeby, xdai, mainnet)
  */
-export const TARGET_NETWORK_INFO: TNetworkInfo = NETWORKS.localhost;
+export const TARGET_NETWORK_INFO: TNetworkInfo = NETWORKS.rinkeby;
 
 if (DEBUG) console.log(`📡 Connecting to ${TARGET_NETWORK_INFO.name}`);
 
@@ -77,4 +77,5 @@ export const MAINNET_PROVIDER =
 // -------------------
 
 if (DEBUG) console.log('🏠 Connecting to provider:', NETWORKS.localhost.rpcUrl);
-export const LOCAL_PROVIDER: TEthersProvider = new StaticJsonRpcProvider(NETWORKS.localhost.rpcUrl);
+export const LOCAL_PROVIDER: TEthersProvider | undefined =
+  TARGET_NETWORK_INFO === NETWORKS.localhost ? new StaticJsonRpcProvider(NETWORKS.localhost.rpcUrl) : undefined;

--- a/packages/vite-app-ts/src/models/constants/networks.ts
+++ b/packages/vite-app-ts/src/models/constants/networks.ts
@@ -1,5 +1,5 @@
 import { TNetworkInfo } from 'eth-hooks/models';
-import { INFURA_ID } from '~~/config/apiKeysConfig';
+import { INFURA_ID } from '../../config/apiKeysConfig';
 
 export type TNetworkNames =
   | 'localhost'


### PR DESCRIPTION
Fixed this issue but web3 modal still won't open because "A valid EthersModalConnector was not provided"

Digging some more, but this one is done with :)