### PR TITLE
Fixed issue where vite couldnt find browserified http/https packages on windows systems.

### DIFF
--- a/packages/vite-app-ts/vite.config.ts
+++ b/packages/vite-app-ts/vite.config.ts
@@ -19,8 +19,8 @@ console.log();
  * browserify for web3 components
  */
 const externals = {
-  http: 'http-browserify',
-  https: 'http-browserify',
+  http: resolve(__dirname, './node_modules/http-browserify'),
+  https: resolve(__dirname, './node_modules/http-browserify'),
   timers: 'timers-browserify',
   electron: 'electron',
   'electron-fetch': 'electron-fetch',


### PR DESCRIPTION
As the title says.

Had to do this to get yarn start to work on windows.