### PR TITLE
Fix nextjs start command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Running the app
 
    ```bash
    # start nextjs app
-   yarn start:next
+   yarn start:nextjs
 
    ```
 


### PR DESCRIPTION
The yarn start:next command doesn't exist
