### PR TITLE
Correction in CLI command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ use `-h` with any command for help.  e.g. yarn set-react -h
 You can change the configuration file to pick different frontends and solidity toolkits.
 
 ```bash
-yarn set-react `nextjs` or `vite`
-yarn set-solidity `hardhat` or `foundry`
+yarn set-react nextjs or vite
+yarn set-solidity hardhat or foundry
 ```
 
 ### Target network


### PR DESCRIPTION
The previous command was 
```
yarn set-react `nextjs` or `vite`
yarn set-solidity `hardhat` or `foundry`
```

Run 
```
yarn set-react `nextjs`
```
which results in
```
zsh: command not found: nextjs

✅ Success! Created scaffold.config.json in packages/common/src
With:  { build: { reactBuild: 'vite' } }
```

---

The new command is 
```
yarn set-react nextjs or vite
yarn set-solidity hardhat or foundry
```

Run 
```
yarn set-react nextjs
```
which results in 
```

✅ Success! Created scaffold.config.json in packages/common/src
With:  { build: { reactBuild: 'nextjs' } }
```
